### PR TITLE
Add VNovels (browser choice-based IF / visual novel authoring tool)

### DIFF
--- a/docs_src/authoring-tools.adoc
+++ b/docs_src/authoring-tools.adoc
@@ -301,7 +301,7 @@ See also:
 
 * https://vnovels.com[vnovels.com^]
 
-A free-to-use, proprietary in-browser authoring tool for branching, choice-based interactive stories and visual novels, featuring a visual graph and scene editor and an AI writing assistant. Build multi-route stories with choices and variables, then publish playable works to the web, no coding required.
+A free to use, proprietary in-browser authoring tool for branching, choice-based visual novels, with a visual graph and scene editor, an AI writing assistant, and AI generation of backgrounds, characters, music and sound. Publishes playable stories to the web, no coding needed.
 
 == XVAN
 

--- a/docs_src/authoring-tools.adoc
+++ b/docs_src/authoring-tools.adoc
@@ -297,6 +297,12 @@ See also:
 
 * https://versu.com/[versu.com^]
 
+== VNovels
+
+* https://vnovels.com[vnovels.com^]
+
+A free-to-use, proprietary in-browser authoring tool for branching, choice-based interactive stories and visual novels, featuring a visual graph and scene editor and an AI writing assistant. Build multi-route stories with choices and variables, then publish playable works to the web, no coding required.
+
 == XVAN
 
 * https://xvan.nl[xvan.nl^]


### PR DESCRIPTION
This adds VNovels (https://vnovels.com), a small browser tool I built for making branching, choice-based visual novels. I put it in the authoring tools section, alphabetically between Versu and XVAN, and edited the AsciiDoc source rather than the generated README. Thanks for keeping this list going.